### PR TITLE
docs: add related to uhtml

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,6 @@ render(
 ```
 
 Please note this module inevitably needs/uses `Function` to evaluate the code within a `with` statement.
+
+## Related
+- [uhtml](https://github.com/WebReflection/uhtml) - A micro HTML/SVG render 


### PR DESCRIPTION
It’s not immediately clear what this package is for, if you don’t know about `uhtml` )))